### PR TITLE
Bug fix: Error handler missing argument

### DIFF
--- a/server/middleware/errorHandlers.js
+++ b/server/middleware/errorHandlers.js
@@ -57,7 +57,7 @@ export class ForbiddenError extends Error {
 /**
  * Entry point for all error handling
  */
-export default function errorHandler(err, req, res) {
+export default function errorHandler(err, req, res, next) {
     // Log the error for debugging
     console.log(`${err.statusCode} ${err.name}: ${err.message}`);
     if (err.statusCode && err.message && err.name) {

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,8 @@ import cors from 'cors';
 const corsOptions = {
   origin: [process.env.CLIENT_URL] // Set to an array of domains we accept requests from
 }
+console.log(`Accepting requests from: ${process.env.CLIENT_URL}`)
+
 
 const app = express();
 app.use(express.urlencoded({ extended: false }));


### PR DESCRIPTION
I thought maybe during deployment, the server wasn't grabbing the client URL. What was actually happening is the middleware error handler must have all 4 arguments (err, req, res, next) even if they aren't all used.